### PR TITLE
SK-1698 remove reference to main

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: main
           fetch-depth: 0
       - uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
To remove the reference to main branch in beta release workflow file as we are referring to a branch starting with "beta-"