### PR TITLE
SK-2131 fix expiry date validation

### DIFF
--- a/__tests__/core-utils/element-validations.test.js
+++ b/__tests__/core-utils/element-validations.test.js
@@ -187,20 +187,38 @@ describe('test validatePin function', () => {
   });
 });
 
-describe('test validateExpiryDate function', () => {
+describe('test validateExpiryDate function with various format', () => {
   it('should return true for current month/year', () => {
     const today = new Date();
     const month = (today.getMonth() + 1).toString().padStart(2, '0');
     const year = today.getFullYear();
     expect(validateExpiryDate(`${month}/${year}`, 'MM/YYYY')).toBe(true);
+    expect(validateExpiryDate(`${year}/${month}`, 'YYYY/MM')).toBe(true);
+
+    const yearTwoDigit = year % 100;
+    expect(validateExpiryDate(`${month}/${yearTwoDigit}`, 'MM/YY')).toBe(true);
+    expect(validateExpiryDate(`${yearTwoDigit}/${month}`, 'YY/MM')).toBe(true);
   });
 
   it('should return true for valid future date', () => {
     expect(validateExpiryDate('07/2074', 'MM/YYYY')).toBe(true);
+    expect(validateExpiryDate('2074/04', 'YYYY/MM')).toBe(true);
+    expect(validateExpiryDate('01/35', 'MM/YY')).toBe(true);
+    expect(validateExpiryDate('35/04', 'YY/MM')).toBe(true);
   });
 
   it('should return false for expired dates', () => {
     expect(validateExpiryDate('01/2020', 'MM/YYYY')).toBe(false);
+    expect(validateExpiryDate('2000/04', 'YYYY/MM')).toBe(false);
+    expect(validateExpiryDate('04/20', 'MM/YY')).toBe(false);
+    expect(validateExpiryDate('20/04', 'YY/MM')).toBe(false);
+  });
+
+  it('should return false for invalid month for expired date', () => {
+    expect(validateExpiryDate('15/2040', 'MM/YYYY')).toBe(false);
+    expect(validateExpiryDate('2040/16', 'YYYY/MM')).toBe(false);
+    expect(validateExpiryDate('14/20', 'MM/YY')).toBe(false);
+    expect(validateExpiryDate('40/14', 'YY/MM')).toBe(false);
   });
 });
 

--- a/src/core-utils/element-validations/index.ts
+++ b/src/core-utils/element-validations/index.ts
@@ -58,6 +58,9 @@ export const validateExpiryDate = (date: string, format: string) => {
   if (date.trim().length === 0) return true;
   if (!date.includes('/')) return false;
   const { month, year } = getYearAndMonthBasedOnFormat(date, format);
+
+  if (month < 1 || month > 12) return false;
+
   const expiryDate = new Date(Number(year), Number(month) - 1, 1);
   const today = new Date();
   today.setDate(1);


### PR DESCRIPTION
- This PR fixes a validation issue in the React Native SDK where a credit card expiration date set to the current month and year was incorrectly flagged as invalid.

### Why:
- The existing `expiry date` validation logic fails when the input is equal to the `current month and year`. This is incorrect, as cards expiring in the current month are still considered valid until the end of the month.

### Outcome: 
- Expiry date validation now correctly accepts the `current month and year` as **valid**.
- No validation error will be shown for cards that are valid through the current month.

### Test: 
- Manually & added unit test.