### PR TITLE
SK-2173 support input formatting in reveal elements

### DIFF
--- a/__tests__/components/__snapshots__/components.test.js.snap
+++ b/__tests__/components/__snapshots__/components.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test Collect And Reveal Elements Components test CardHolderNameElement component 1`] = `
+exports[`test Collect Elements Components test CardHolderNameElement component 1`] = `
 <View>
   <Text
     style={Object {}}
@@ -31,7 +31,7 @@ exports[`test Collect And Reveal Elements Components test CardHolderNameElement 
 </View>
 `;
 
-exports[`test Collect And Reveal Elements Components test CardNumberElement component 1`] = `
+exports[`test Collect Elements Components test CardNumberElement component 1`] = `
 <View>
   <Text
     style={Object {}}
@@ -95,7 +95,7 @@ exports[`test Collect And Reveal Elements Components test CardNumberElement comp
 </View>
 `;
 
-exports[`test Collect And Reveal Elements Components test CvvElement component 1`] = `
+exports[`test Collect Elements Components test CvvElement component 1`] = `
 <View>
   <Text
     style={Object {}}
@@ -128,7 +128,7 @@ exports[`test Collect And Reveal Elements Components test CvvElement component 1
 </View>
 `;
 
-exports[`test Collect And Reveal Elements Components test ExpirationDateElement component 1`] = `
+exports[`test Collect Elements Components test ExpirationDateElement component 1`] = `
 <View>
   <Text
     style={Object {}}
@@ -161,7 +161,7 @@ exports[`test Collect And Reveal Elements Components test ExpirationDateElement 
 </View>
 `;
 
-exports[`test Collect And Reveal Elements Components test ExpirationMonthElement component 1`] = `
+exports[`test Collect Elements Components test ExpirationMonthElement component 1`] = `
 <View>
   <Text
     style={Object {}}
@@ -194,7 +194,7 @@ exports[`test Collect And Reveal Elements Components test ExpirationMonthElement
 </View>
 `;
 
-exports[`test Collect And Reveal Elements Components test ExpirationYearElement component 1`] = `
+exports[`test Collect Elements Components test ExpirationYearElement component 1`] = `
 <View>
   <Text
     style={Object {}}
@@ -227,7 +227,7 @@ exports[`test Collect And Reveal Elements Components test ExpirationYearElement 
 </View>
 `;
 
-exports[`test Collect And Reveal Elements Components test InputFieldElement component 1`] = `
+exports[`test Collect Elements Components test InputFieldElement component 1`] = `
 <View>
   <Text
     style={Object {}}
@@ -258,7 +258,7 @@ exports[`test Collect And Reveal Elements Components test InputFieldElement comp
 </View>
 `;
 
-exports[`test Collect And Reveal Elements Components test PinElement component 1`] = `
+exports[`test Collect Elements Components test PinElement component 1`] = `
 <View>
   <Text
     style={Object {}}
@@ -291,7 +291,7 @@ exports[`test Collect And Reveal Elements Components test PinElement component 1
 </View>
 `;
 
-exports[`test Collect And Reveal Elements Components test RevealElement component 1`] = `
+exports[`test Collect Elements Components test Reveal Elements Components renders correctly with the handler & snapshot 1`] = `
 Array [
   <Text
     style={Object {}}
@@ -311,7 +311,7 @@ Array [
 ]
 `;
 
-exports[`test Collect And Reveal Elements Components test skyflow provider 1`] = `
+exports[`test Collect Elements Components test skyflow provider 1`] = `
 <Text>
   Provider Childern
 </Text>

--- a/__tests__/components/components.test.js
+++ b/__tests__/components/components.test.js
@@ -37,7 +37,7 @@ const changeTrigger = jest.fn();
 const foucsTrigger = jest.fn();
 const blurTrigger = jest.fn();
 
-describe('test Collect And Reveal Elements Components', () => {
+describe('test Collect Elements Components', () => {
   let collectContainer;
   beforeEach(() => {
     jest.clearAllMocks();
@@ -558,44 +558,102 @@ describe('test Collect And Reveal Elements Components', () => {
     }
   });
 
-  it('test RevealElement component', () => {
-    const revealSetMethodMock = jest.fn();
-    const revealContainer = new RevealContainer(testSkyflowClient);
-    jest.spyOn(revealContainer, 'create').mockImplementation(() => ({
-      setMethods: revealSetMethodMock,
-    }));
+  describe('test Reveal Elements Components', () => {
+    it('renders correctly with the handler & snapshot', () => {
+      const revealSetMethodMock = jest.fn();
+      const revealContainer = new RevealContainer(testSkyflowClient);
+      jest.spyOn(revealContainer, 'create').mockImplementation(() => ({
+        setMethods: revealSetMethodMock,
+      }));
 
-    const revealElement = render(
-      <RevealElement
-        token={'test_token'}
-        container={revealContainer}
-        label={'Card Number'}
-        altText={'XXXX XXXX XXXX XXXX'}
-      />
-    );
-
-    expect(revealElement).toMatchSnapshot();
-    expect(revealSetMethodMock).toBeCalledTimes(1);
-
-    // render without alttext
-    const revealElement2 = render(
-      <RevealElement
-        token={'test_token'}
-        container={revealContainer}
-        label={'Card Number'}
-      />
-    );
-    try {
-      render(<RevealElement token={'test_token'} label={'Card Number'} />);
-    } catch (err) {
-      expect(err).toEqual(
-        new SkyflowError(
-          SKYFLOW_ERROR_CODE.CONTAINER_OBJECT_IS_REQUIRED,
-          ['Reveal', 'useRevealContainer()'],
-          true
-        )
+      const revealElement = render(
+        <RevealElement
+          token={'test_token'}
+          container={revealContainer}
+          label={'Card Number'}
+          altText={'XXXX XXXX XXXX XXXX'}
+        />
       );
-    }
+
+      expect(revealElement).toMatchSnapshot();
+      expect(revealSetMethodMock).toBeCalledTimes(1);
+
+      // render without alttext
+      const revealElement2 = render(
+        <RevealElement
+          token={'test_token'}
+          container={revealContainer}
+          label={'Card Number'}
+        />
+      );
+      try {
+        render(<RevealElement token={'test_token'} label={'Card Number'} />);
+      } catch (err) {
+        expect(err).toEqual(
+          new SkyflowError(
+            SKYFLOW_ERROR_CODE.CONTAINER_OBJECT_IS_REQUIRED,
+            ['Reveal', 'useRevealContainer()'],
+            true
+          )
+        );
+      }
+    });
+
+    it('renders formatted value when format is provided', () => {
+      const revealSetMethodMock = jest.fn();
+      const revealContainer = new RevealContainer(testSkyflowClient);
+      jest.spyOn(revealContainer, 'create').mockImplementation(() => ({
+        setMethods: revealSetMethodMock,
+      }));
+
+      const format = 'XXXX XXXX XXXX XXXX';
+      const altText = '4111111111111111';
+
+      render(
+        <RevealElement
+          token={'test_token'}
+          container={revealContainer}
+          label={'Card Number'}
+          altText={altText}
+          format={format}
+          testID="reveal-format"
+        />
+      );
+
+      // Should format altText using format
+      expect(screen.getByTestId('reveal-format').props.children).toBe(
+        '4111 1111 1111 1111'
+      );
+    });
+
+    it('renders formatted value when format and translation are provided', () => {
+      const revealSetMethodMock = jest.fn();
+      const revealContainer = new RevealContainer(testSkyflowClient);
+      jest.spyOn(revealContainer, 'create').mockImplementation(() => ({
+        setMethods: revealSetMethodMock,
+      }));
+
+      const format = 'XX-XX-XX-YYZ-ZZX';
+      const translation = { X: '[0-9]', Y: '[A-Z]' };
+      const altText = '123456AB7';
+
+      render(
+        <RevealElement
+          token={'test_token'}
+          container={revealContainer}
+          label={'Code'}
+          altText={altText}
+          format={format}
+          translation={translation}
+          testID="reveal-format-translation"
+        />
+      );
+
+      // Should format altText using format and translation
+      expect(
+        screen.getByTestId('reveal-format-translation').props.children
+      ).toBe('12-34-56-ABZ-ZZ7');
+    });
   });
 
   it('test skyflow provider', () => {

--- a/src/components/RevealElement/index.tsx
+++ b/src/components/RevealElement/index.tsx
@@ -7,12 +7,21 @@ import RevealSkyflowElement from "../../core/RevealSkyflowElement";
 import { RevealElementProps } from "../../utils/constants"
 import SkyflowError from "../../utils/skyflow-error";
 import SKYFLOW_ERROR_CODE from "../../utils/skyflow-error-code";
+import { formatInputFieldValue } from "../../utils/helpers";
+import { DEFAULT_INPUT_FIELD_TRANSLATION } from "../../core/constants";
 
 
-const RevealElement: React.FC<RevealElementProps> = ({ container, label, ...rest }) => {
+const RevealElement: React.FC<RevealElementProps> = ({ container, label, format, translation, ...rest }) => {
     const [element, setElement] = React.useState<RevealSkyflowElement>(undefined);
     const [errorText, setErrorText] = React.useState<string>('');
     const [value, setValue] = React.useState(rest?.altText || rest.token);
+
+    const formattedValue = React.useMemo(() => {
+        if (!format) return value;
+        const valueTranslation = translation ?? DEFAULT_INPUT_FIELD_TRANSLATION;
+        const formattedText = formatInputFieldValue(value, format, valueTranslation);
+        return formattedText ? formattedText : value;
+      }, [value, format, translation]);
 
     useEffect(() => {
         if (container) {
@@ -22,12 +31,11 @@ const RevealElement: React.FC<RevealElementProps> = ({ container, label, ...rest
         } else {
             throw new SkyflowError(SKYFLOW_ERROR_CODE.CONTAINER_OBJECT_IS_REQUIRED, ['Reveal', 'useRevealContainer()'], true)
         }
-
     }, []);
 
     return <>
         <Text style={rest.labelStyles?.base || {}}>{label}</Text>
-        <Text selectable style={rest?.inputStyles?.base || {}} testID={rest?.testID}>{value}</Text>
+        <Text selectable style={rest?.inputStyles?.base || {}} testID={rest?.testID}>{formattedValue}</Text>
         <Text style={rest?.errorTextStyles?.base || {}} testID={`${label}-error`}>{errorText}</Text>
     </>
 

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -109,6 +109,8 @@ export interface RevealElementInput {
 export interface RevealElementProps {
   token: string;
   container: RevealContainer;
+  format?: string
+  translation?: Record<string, string>;
   label?: string;
   altText?: string;
   inputStyles?: StylesBaseVariant;


### PR DESCRIPTION
### Why:
- The `React Native SDK` currently lacks support for applying **input formatting** (e.g., `XXX-XX-XXXX`) in **Reveal element**.
- This capability is available in other client-side SDKs such as JavaScript & React, creating an inconsistency in user experience.

### Outcome:
- Users should be able to define `format` & `translation` in reveal elements to reveal data.

- The defined formatting should be automatically applied in the UI, when user reveals.

### Testing:
- Tested locally & added unit tests.