### PR TITLE
SK-2173 revert unformatted card no insertion to vault

### DIFF
--- a/__tests__/core-utils/collect.test.js
+++ b/__tests__/core-utils/collect.test.js
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 2022 Skyflow, Inc.
 */
-import { tokenize, getElementValueToInsert } from '../../src/core-utils/collect';
+import { tokenize } from '../../src/core-utils/collect';
 import CollectElement from '../../src/core/CollectElement';
 import Skyflow from '../../src/core/Skyflow';
 import { ElementType, Env, LogLevel } from '../../src/utils/constants';
@@ -524,32 +524,4 @@ describe('test collect utils class', () => {
       });
   });
 
-});
-
-describe('getVaultInsertValue', () => {
-  class MockCollectElement {
-    constructor(type, value) {
-      this.type = type;
-      this.value = value;
-    }
-    getClientState() {
-      return { elementType: this.type };
-    }
-    getUnformattedValue() {
-      return this.value.replace(/[\s-]/g, '');
-    }
-    getInternalState() {
-      return { value: this.value };
-    }
-  }
-
-  test('returns unformatted value for CARD_NUMBER', () => {
-    const element = new MockCollectElement(ElementType.CARD_NUMBER, '4111 1111 1111 1111');
-    expect(getElementValueToInsert(element)).toBe('4111111111111111');
-  });
-
-  test('returns value as is for non-CARD_NUMBER', () => {
-    const element = new MockCollectElement(ElementType.CVV, '123');
-    expect(getElementValueToInsert(element)).toBe('123');
-  });
 });

--- a/__tests__/core/collectElement.test.js
+++ b/__tests__/core/collectElement.test.js
@@ -524,30 +524,6 @@ describe('test Collect Element class', () => {
     );
   });
 
-  it('should remove spaces from value', () => {
-    const elementInput = {
-      table: 'cards',
-      column: 'number',
-      type: ElementType.CARD_NUMBER,
-      containerType: ContainerType.COLLECT,
-    };
-    const collectElement = new CollectElement(elementInput, {}, context);
-    collectElement.updateValue('4111 1111 1111 1111');
-    expect(collectElement.getUnformattedValue()).toBe('4111111111111111');
-  });
-
-  it('should remove hyphens from value', () => {
-    const elementInput = {
-      table: 'cards',
-      column: 'number',
-      type: ElementType.CARD_NUMBER,
-      containerType: ContainerType.COLLECT,
-    };
-    const collectElement = new CollectElement(elementInput, {}, context);
-    collectElement.updateValue('4111-1111-1111-1111');
-    expect(collectElement.getUnformattedValue()).toBe('4111111111111111');
-  });
-
   it('test format option in card number element', () => {
     const formatTestCases = [
       // Test different valid formats for the card number

--- a/src/core-utils/collect/index.ts
+++ b/src/core-utils/collect/index.ts
@@ -229,14 +229,14 @@ export const tokenize = (
         set(
           elementsUpdateData[skyflowID],
           column,
-          getElementValueToInsert(currentElement),
+          currentElement.getInternalState().value,
         );
       } else {
         elementsUpdateData[skyflowID] = {};
         set(
           elementsUpdateData[skyflowID],
           column,
-          getElementValueToInsert(currentElement),
+          currentElement.getInternalState().value,
         );
         set(
           elementsUpdateData[skyflowID],
@@ -246,10 +246,10 @@ export const tokenize = (
       }
     }
     else if (elementsData[table]) {
-      set(elementsData[table], column, getElementValueToInsert(currentElement));
+      set(elementsData[table], column, currentElement.getInternalState().value);
     } else {
       elementsData[table] = {};
-      set(elementsData[table], column, getElementValueToInsert(currentElement));
+      set(elementsData[table], column, currentElement.getInternalState().value);
     }
   });
 


### PR DESCRIPTION
**Why**
- Revert unformatted card number insertion in the vault to preserve the existing behaviour(inserting formatted card no).

**Outcome**: 
- It will insert the formatted car number in the vault.