### PR TITLE
SK-2618: Fix build script to correctly include compiled lib output in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepare": "bob build",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn && yarn example pods",
-    "build": "bob build && cp -r assets lib/ && cp package.json lib/"
+    "build": "bob build"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
**Why**

- The previous build script copied assets and package.json into the lib directory after bob build.
- As a result, the compiled directories (lib/commonjs, lib/module, lib/typescript) were missing in the published npm package starting from 1.10.0.

**Outcome**

- Updated the build script to run only bob build.
- Ensures compiled outputs (commonjs, module, typescript) are generated and included in the npm package.
- Restores proper module resolution and TypeScript support for consumers.