### PR TITLE
SK-2658 add all query params available in get

### DIFF
--- a/README.md
+++ b/README.md
@@ -1396,36 +1396,54 @@ For non-PCI use-cases, retrieving data from the vault and revealing it in the mo
 - #### Using Skyflow ID's or Unique Column Values
     For retrieving data from the vault, use the `get(getInput: IGetInput, options: IGetOptions)` method.
     
-    The `getInput` parameter takes an object that contains an array of the records to fetch. Each object inside array should contain:
+    The `getInput` parameter takes an object that contains an array of the records to fetch. Each object inside the array should contain:
 
     - Either an array of Skyflow IDs to fetch
     - Or a column name and an array of column values
 
-    The second parameter, `options`, is a `GetOptions` object that retrieves tokens of Skyflow IDs. 
+    The second parameter, `options`, is a `GetOptions` object that controls how records are retrieved.
 
-    Notes: 
-    - You can use either Skyflow IDs or unique values to retrieve records. You can't use both at the same time.
-    - GetOptions parameter is applicable only for retrieving tokens using Skyflow ID.
-    - You can't pass GetOptions along with the redaction type.
+    Notes:
+    - You can use either Skyflow IDs or unique column values to retrieve records. You can't use both at the same time.
+    - `tokens: true` is only applicable when fetching by Skyflow IDs and cannot be combined with `redaction`.
+    - Use `fields` to restrict which columns are returned — required when column-scoped policies limit access to certain fields.
+    - `offset` and `limit` are per-record and support pagination across results.
+    - `orderBy` accepts `OrderBy.ASCENDING`, `OrderBy.DESCENDING`, or `OrderBy.NONE`.
     - `tokens` defaults to false.
-    
+
     ```json5
     {
-      "records":[
+      "records": [
         {
           "ids": Array,                  // Array of SkyflowID's of the records to be fetched
           "table": String,               // name of table holding the above skyflow_id's
-          "redaction": RedactionType     // redaction to be applied to retrieved data
+          "redaction": RedactionType,    // redaction to be applied to retrieved data
+          "fields": Array,               // (optional) columns to return; omit to return all permitted columns
+          "offset": String,              // (optional) pagination start position
+          "limit": String                // (optional) max number of records to return
         },
         {
           "table": String,               // name of table from where records are to be fetched
           "redaction": RedactionType,    // redaction to be applied to retrieved data
           "columnName": String,          // a unique column name
-          "columnValues": Array         // Array of Column Values of the records to be fetched
+          "columnValues": Array,         // Array of Column Values of the records to be fetched
+          "fields": Array,               // (optional) columns to return; omit to return all permitted columns
+          "offset": String,              // (optional) pagination start position
+          "limit": String                // (optional) max number of records to return
         }
       ]
     }
     ```
+
+    ```json5
+    // options
+    {
+      "tokens": Boolean,       // if true, returns tokens instead of plain-text values
+      "downloadURL": Boolean,  // (optional) if true, returns pre-signed download URLs for file columns
+      "orderBy": OrderBy       // (optional) sort order: OrderBy.ASCENDING | OrderBy.DESCENDING | OrderBy.NONE
+    }
+    ```
+
   An Example of Get call to fetch records
 
   ```js
@@ -1527,11 +1545,69 @@ For non-PCI use-cases, retrieving data from the vault and revealing it in the mo
           "code": "404",
           "description": "No Records Found"
         },
-        "columnName": "email",
+        "columnName": "email"
       }
     ]
   }
   ```
+
+  An Example of Get call to fetch specific fields (column-scoped policy compatible)
+
+  ```js
+  const skyflowContainer = useSkyflow();
+
+  const getRequestInput = {
+    records: [
+      {
+        ids: ['h4f5k569-c577-8o1j-r91c-x9gfd0b0fd9'],
+        table: 'persons',
+        redaction: RedactionType.PLAIN_TEXT,
+        fields: ['occupation', 'annual_income'],
+      },
+    ],
+  };
+
+  skyflowContainer
+    .get(getRequestInput, { tokens: false })
+    .then((response) => {
+      console.log(JSON.stringify(response));
+    })
+    .catch((err) => {
+      console.error(JSON.stringify(err));
+    });
+  ```
+
+  An Example of Get call to fetch records with pagination and ordering
+
+  ```js
+  import { useSkyflow, RedactionType, OrderBy } from 'skyflow-react-native';
+
+  const skyflowContainer = useSkyflow();
+
+  const getRequestInput = {
+    records: [
+      {
+        table: 'customers',
+        redaction: RedactionType.PLAIN_TEXT,
+        columnName: 'email',
+        columnValues: ['john.doe@gmail.com'],
+        fields: ['name', 'email'],
+        offset: '0',
+        limit: '10',
+      },
+    ],
+  };
+
+  skyflowContainer
+    .get(getRequestInput, { tokens: false, orderBy: OrderBy.ASCENDING })
+    .then((response) => {
+      console.log(JSON.stringify(response));
+    })
+    .catch((err) => {
+      console.error(JSON.stringify(err));
+    });
+  ```
+
   An Example of Get call to fetch Tokens
 
   ```js

--- a/__tests__/core-utils/element-validations.test.js
+++ b/__tests__/core-utils/element-validations.test.js
@@ -1000,54 +1000,90 @@ describe('test get options validation', () => {
     }
   });
 
-  it('should throw error for non-string offset in get options', () => {
+  it('should throw error for non-string offset in record', () => {
     try {
-      validateGetInput(
-        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
-        { offset: 10 }
-      );
+      validateGetInput({
+        records: [
+          {
+            ids: ['123'],
+            table: 'test',
+            redaction: RedactionType.DEFAULT,
+            offset: 10,
+          },
+        ],
+      });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET.description,
+          0
+        )
       );
     }
   });
 
-  it('should throw error for null offset in get options', () => {
+  it('should throw error for null offset in record', () => {
     try {
-      validateGetInput(
-        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
-        { offset: null }
-      );
+      validateGetInput({
+        records: [
+          {
+            ids: ['123'],
+            table: 'test',
+            redaction: RedactionType.DEFAULT,
+            offset: null,
+          },
+        ],
+      });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET.description,
+          0
+        )
       );
     }
   });
 
-  it('should throw error for non-string limit in get options', () => {
+  it('should throw error for non-string limit in record', () => {
     try {
-      validateGetInput(
-        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
-        { limit: true }
-      );
+      validateGetInput({
+        records: [
+          {
+            ids: ['123'],
+            table: 'test',
+            redaction: RedactionType.DEFAULT,
+            limit: true,
+          },
+        ],
+      });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET.description,
+          0
+        )
       );
     }
   });
 
-  it('should throw error for null limit in get options', () => {
+  it('should throw error for null limit in record', () => {
     try {
-      validateGetInput(
-        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
-        { limit: null }
-      );
+      validateGetInput({
+        records: [
+          {
+            ids: ['123'],
+            table: 'test',
+            redaction: RedactionType.DEFAULT,
+            limit: null,
+          },
+        ],
+      });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET.description,
+          0
+        )
       );
     }
   });
@@ -1117,12 +1153,19 @@ describe('test get options validation', () => {
     }
   });
 
-  it('should not throw for valid offset and limit in get options', () => {
+  it('should not throw for valid offset and limit in record', () => {
     expect(() =>
-      validateGetInput(
-        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
-        { offset: '5', limit: '10' }
-      )
+      validateGetInput({
+        records: [
+          {
+            ids: ['123'],
+            table: 'test',
+            redaction: RedactionType.DEFAULT,
+            offset: '5',
+            limit: '10',
+          },
+        ],
+      })
     ).not.toThrow();
   });
 
@@ -1163,81 +1206,92 @@ describe('test get options validation', () => {
   });
 });
 
-describe('test validateGetInput fields in options', () => {
+describe('test validateGetInput fields in record', () => {
   const validRecord = { ids: ['123'], table: 'test', redaction: RedactionType.PLAIN_TEXT };
 
-  it('should throw error for null fields in options', () => {
+  it('should throw error for null fields in record', () => {
     try {
-      validateGetInput({ records: [validRecord] }, { fields: null });
+      validateGetInput({ records: [{ ...validRecord, fields: null }] });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.INVALID_FIELDS_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.INVALID_FIELDS_IN_GET.description,
+          0
+        )
       );
     }
   });
 
-  it('should throw error for non-array fields in options', () => {
+  it('should throw error for non-array fields in record', () => {
     try {
-      validateGetInput(
-        { records: [validRecord] },
-        { fields: 'occupation' }
-      );
+      validateGetInput({ records: [{ ...validRecord, fields: 'occupation' }] });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.INVALID_FIELDS_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.INVALID_FIELDS_IN_GET.description,
+          0
+        )
       );
     }
   });
 
-  it('should throw error for empty fields array in options', () => {
+  it('should throw error for empty fields array in record', () => {
     try {
-      validateGetInput(
-        { records: [validRecord] },
-        { fields: [] }
-      );
+      validateGetInput({ records: [{ ...validRecord, fields: [] }] });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.EMPTY_FIELDS_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.EMPTY_FIELDS_IN_GET.description,
+          0
+        )
       );
     }
   });
 
-  it('should throw error for non-string value inside fields array in options', () => {
+  it('should throw error for non-string value inside fields array in record', () => {
     try {
-      validateGetInput({ records: [validRecord] }, { fields: [123] });
+      validateGetInput({ records: [{ ...validRecord, fields: [123] }] });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.INVALID_FIELD_VALUE_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.INVALID_FIELD_VALUE_IN_GET.description,
+          0
+        )
       );
     }
   });
 
-  it('should throw error for null value inside fields array in options', () => {
+  it('should throw error for null value inside fields array in record', () => {
     try {
-      validateGetInput({ records: [validRecord] }, { fields: [null] });
+      validateGetInput({ records: [{ ...validRecord, fields: [null] }] });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.INVALID_FIELD_VALUE_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.INVALID_FIELD_VALUE_IN_GET.description,
+          0
+        )
       );
     }
   });
 
-  it('should throw error for empty string inside fields array in options', () => {
+  it('should throw error for empty string inside fields array in record', () => {
     try {
-      validateGetInput({ records: [validRecord] }, { fields: [''] });
+      validateGetInput({ records: [{ ...validRecord, fields: [''] }] });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        SKYFLOW_ERROR_CODE.EMPTY_FIELD_VALUE_IN_GET.description
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.EMPTY_FIELD_VALUE_IN_GET.description,
+          0
+        )
       );
     }
   });
 
-  it('should not throw for valid fields array in options', () => {
+  it('should not throw for valid fields array in record', () => {
     expect(() =>
-      validateGetInput(
-        { records: [validRecord] },
-        { fields: ['occupation', 'annual_income'] }
-      )
+      validateGetInput({
+        records: [{ ...validRecord, fields: ['occupation', 'annual_income'] }],
+      })
     ).not.toThrow();
   });
 });

--- a/__tests__/core-utils/element-validations.test.js
+++ b/__tests__/core-utils/element-validations.test.js
@@ -328,12 +328,15 @@ describe('test validateGetInput', () => {
     }
   });
 
-  it('should throw error for empty ids', () => {
+  it('should throw error for missing table when ids is empty array', () => {
     try {
       validateGetInput({ records: [{ ids: [] }] });
     } catch (err) {
       expect(err?.errors[0]?.description).toEqual(
-        parameterizedString(SKYFLOW_ERROR_CODE.EMPTY_IDS_IN_GET.description, 0)
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.MISSING_TABLE_IN_GET.description,
+          0
+        )
       );
     }
   });

--- a/__tests__/core-utils/element-validations.test.js
+++ b/__tests__/core-utils/element-validations.test.js
@@ -996,4 +996,245 @@ describe('test get options validation', () => {
       );
     }
   });
+
+  it('should throw error for non-string offset in get options', () => {
+    try {
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { offset: 10 }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for null offset in get options', () => {
+    try {
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { offset: null }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for non-string limit in get options', () => {
+    try {
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { limit: true }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for null limit in get options', () => {
+    try {
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { limit: null }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for non-boolean downloadURL in get options', () => {
+    try {
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { downloadURL: 'true' }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_DOWNLOAD_URL_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for number passed as downloadURL in get options', () => {
+    try {
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { downloadURL: 1 }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_DOWNLOAD_URL_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for null downloadURL in get options', () => {
+    try {
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { downloadURL: null }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_DOWNLOAD_URL_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for invalid orderBy value in get options', () => {
+    try {
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { orderBy: 'INVALID_ORDER' }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_ORDER_BY_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for null orderBy in get options', () => {
+    try {
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { orderBy: null }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_ORDER_BY_IN_GET.description
+      );
+    }
+  });
+
+  it('should not throw for valid offset and limit in get options', () => {
+    expect(() =>
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { offset: '5', limit: '10' }
+      )
+    ).not.toThrow();
+  });
+
+  it('should not throw for valid downloadURL in get options', () => {
+    expect(() =>
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { downloadURL: true }
+      )
+    ).not.toThrow();
+  });
+
+  it('should not throw for valid orderBy ASCENDING in get options', () => {
+    expect(() =>
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { orderBy: 'ASCENDING' }
+      )
+    ).not.toThrow();
+  });
+
+  it('should not throw for valid orderBy DESCENDING in get options', () => {
+    expect(() =>
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { orderBy: 'DESCENDING' }
+      )
+    ).not.toThrow();
+  });
+
+  it('should not throw for valid orderBy NONE in get options', () => {
+    expect(() =>
+      validateGetInput(
+        { records: [{ ids: ['123'], table: 'test', redaction: RedactionType.DEFAULT }] },
+        { orderBy: 'NONE' }
+      )
+    ).not.toThrow();
+  });
+});
+
+describe('test validateGetInput fields in options', () => {
+  const validRecord = { ids: ['123'], table: 'test', redaction: RedactionType.PLAIN_TEXT };
+
+  it('should throw error for null fields in options', () => {
+    try {
+      validateGetInput({ records: [validRecord] }, { fields: null });
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_FIELDS_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for non-array fields in options', () => {
+    try {
+      validateGetInput(
+        { records: [validRecord] },
+        { fields: 'occupation' }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_FIELDS_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for empty fields array in options', () => {
+    try {
+      validateGetInput(
+        { records: [validRecord] },
+        { fields: [] }
+      );
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.EMPTY_FIELDS_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for non-string value inside fields array in options', () => {
+    try {
+      validateGetInput({ records: [validRecord] }, { fields: [123] });
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_FIELD_VALUE_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for null value inside fields array in options', () => {
+    try {
+      validateGetInput({ records: [validRecord] }, { fields: [null] });
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.INVALID_FIELD_VALUE_IN_GET.description
+      );
+    }
+  });
+
+  it('should throw error for empty string inside fields array in options', () => {
+    try {
+      validateGetInput({ records: [validRecord] }, { fields: [''] });
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        SKYFLOW_ERROR_CODE.EMPTY_FIELD_VALUE_IN_GET.description
+      );
+    }
+  });
+
+  it('should not throw for valid fields array in options', () => {
+    expect(() =>
+      validateGetInput(
+        { records: [validRecord] },
+        { fields: ['occupation', 'annual_income'] }
+      )
+    ).not.toThrow();
+  });
 });

--- a/__tests__/core-utils/element-validations.test.js
+++ b/__tests__/core-utils/element-validations.test.js
@@ -1088,6 +1088,50 @@ describe('test get options validation', () => {
     }
   });
 
+  it('should throw error for empty string offset in record', () => {
+    try {
+      validateGetInput({
+        records: [
+          {
+            ids: ['123'],
+            table: 'test',
+            redaction: RedactionType.DEFAULT,
+            offset: '',
+          },
+        ],
+      });
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.EMPTY_OFFSET_IN_GET.description,
+          0
+        )
+      );
+    }
+  });
+
+  it('should throw error for empty string limit in record', () => {
+    try {
+      validateGetInput({
+        records: [
+          {
+            ids: ['123'],
+            table: 'test',
+            redaction: RedactionType.DEFAULT,
+            limit: '',
+          },
+        ],
+      });
+    } catch (err) {
+      expect(err?.errors[0]?.description).toEqual(
+        parameterizedString(
+          SKYFLOW_ERROR_CODE.EMPTY_LIMIT_IN_GET.description,
+          0
+        )
+      );
+    }
+  });
+
   it('should throw error for non-boolean downloadURL in get options', () => {
     try {
       validateGetInput(

--- a/__tests__/core-utils/reveal.test.js
+++ b/__tests__/core-utils/reveal.test.js
@@ -675,4 +675,249 @@ describe('fetchRecordGET fn test', () => {
         done(err);
       });
   });
+
+  it('should include fields params in url when fields are specified in options', (done) => {
+    let reqArg;
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: (args) => {
+        reqArg = args;
+        return Promise.resolve(getSuccessResponse);
+      },
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], { ...optionsFalse, fields: ['occupation', 'annual_income'] })
+      .then((res) => {
+        expect(reqArg.url).toContain('fields=occupation');
+        expect(reqArg.url).toContain('fields=annual_income');
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should include offset and limit params in url when specified in options', (done) => {
+    let reqArg;
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: (args) => {
+        reqArg = args;
+        return Promise.resolve(getSuccessResponse);
+      },
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], { ...optionsFalse, offset: '5', limit: '10' })
+      .then((res) => {
+        expect(reqArg.url).toContain('offset=5');
+        expect(reqArg.url).toContain('limit=10');
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should include downloadURL param in url when specified in options', (done) => {
+    let reqArg;
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: (args) => {
+        reqArg = args;
+        return Promise.resolve(getSuccessResponse);
+      },
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], { ...optionsFalse, downloadURL: true })
+      .then((res) => {
+        expect(reqArg.url).toContain('downloadURL=true');
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should include order_by param in url when orderBy is specified in options', (done) => {
+    let reqArg;
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: (args) => {
+        reqArg = args;
+        return Promise.resolve(getSuccessResponse);
+      },
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], { ...optionsFalse, orderBy: 'ASCENDING' })
+      .then((res) => {
+        expect(reqArg.url).toContain('order_by=ASCENDING');
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should not include trailing & when all optional params are absent', (done) => {
+    let reqArg;
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: (args) => {
+        reqArg = args;
+        return Promise.resolve(getSuccessResponse);
+      },
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], optionsFalse)
+      .then((res) => {
+        expect(reqArg.url).not.toMatch(/&$/);
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should include all new params together in url', (done) => {
+    let reqArg;
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: (args) => {
+        reqArg = args;
+        return Promise.resolve(getSuccessResponse);
+      },
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
+
+    const opts = {
+      ...optionsFalse,
+      fields: ['name', 'dob'],
+      offset: '0',
+      limit: '25',
+      downloadURL: false,
+      orderBy: 'DESCENDING',
+    };
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], opts)
+      .then((res) => {
+        expect(reqArg.url).toContain('fields=name');
+        expect(reqArg.url).toContain('fields=dob');
+        expect(reqArg.url).toContain('offset=0');
+        expect(reqArg.url).toContain('limit=25');
+        expect(reqArg.url).toContain('downloadURL=false');
+        expect(reqArg.url).toContain('order_by=DESCENDING');
+        expect(reqArg.url).not.toMatch(/&$/);
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should include order_by=NONE in url when orderBy is NONE', (done) => {
+    let reqArg;
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: (args) => {
+        reqArg = args;
+        return Promise.resolve(getSuccessResponse);
+      },
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], {
+      ...optionsFalse,
+      orderBy: 'NONE',
+    })
+      .then((res) => {
+        expect(reqArg.url).toContain('order_by=NONE');
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should not include new params in url when only fields is set', (done) => {
+    let reqArg;
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: (args) => {
+        reqArg = args;
+        return Promise.resolve(getSuccessResponse);
+      },
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest
+      .spyOn(testSkyflowClient, 'getAccessToken')
+      .mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], {
+      ...optionsFalse,
+      fields: ['name'],
+    })
+      .then((res) => {
+        expect(reqArg.url).toContain('fields=name');
+        expect(reqArg.url).not.toContain('offset');
+        expect(reqArg.url).not.toContain('limit');
+        expect(reqArg.url).not.toContain('downloadURL');
+        expect(reqArg.url).not.toContain('order_by');
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
 });

--- a/__tests__/core-utils/reveal.test.js
+++ b/__tests__/core-utils/reveal.test.js
@@ -693,7 +693,11 @@ describe('fetchRecordGET fn test', () => {
 
     jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
 
-    fetchRecordsGET(testSkyflowClient, [getRecordID], { ...optionsFalse, fields: ['occupation', 'annual_income'] })
+    const recordWithFields = {
+      ...getRecordID,
+      fields: ['occupation', 'annual_income'],
+    };
+    fetchRecordsGET(testSkyflowClient, [recordWithFields], optionsFalse)
       .then((res) => {
         expect(reqArg.url).toContain('fields=occupation');
         expect(reqArg.url).toContain('fields=annual_income');
@@ -704,7 +708,7 @@ describe('fetchRecordGET fn test', () => {
       });
   });
 
-  it('should include offset and limit params in url when specified in options', (done) => {
+  it('should include offset and limit params in url when specified in record', (done) => {
     let reqArg;
     jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
       request: (args) => {
@@ -721,7 +725,8 @@ describe('fetchRecordGET fn test', () => {
 
     jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
 
-    fetchRecordsGET(testSkyflowClient, [getRecordID], { ...optionsFalse, offset: '5', limit: '10' })
+    const recordWithPagination = { ...getRecordID, offset: '5', limit: '10' };
+    fetchRecordsGET(testSkyflowClient, [recordWithPagination], optionsFalse)
       .then((res) => {
         expect(reqArg.url).toContain('offset=5');
         expect(reqArg.url).toContain('limit=10');
@@ -830,16 +835,19 @@ describe('fetchRecordGET fn test', () => {
 
     jest.spyOn(testSkyflowClient, 'getAccessToken').mockResolvedValue('valid token');
 
-    const opts = {
-      ...optionsFalse,
+    const recordWithFields = {
+      ...getRecordID,
       fields: ['name', 'dob'],
       offset: '0',
       limit: '25',
+    };
+    const opts = {
+      ...optionsFalse,
       downloadURL: false,
       orderBy: 'DESCENDING',
     };
 
-    fetchRecordsGET(testSkyflowClient, [getRecordID], opts)
+    fetchRecordsGET(testSkyflowClient, [recordWithFields], opts)
       .then((res) => {
         expect(reqArg.url).toContain('fields=name');
         expect(reqArg.url).toContain('fields=dob');
@@ -904,10 +912,8 @@ describe('fetchRecordGET fn test', () => {
       .spyOn(testSkyflowClient, 'getAccessToken')
       .mockResolvedValue('valid token');
 
-    fetchRecordsGET(testSkyflowClient, [getRecordID], {
-      ...optionsFalse,
-      fields: ['name'],
-    })
+    const recordWithFields = { ...getRecordID, fields: ['name'] };
+    fetchRecordsGET(testSkyflowClient, [recordWithFields], optionsFalse)
       .then((res) => {
         expect(reqArg.url).toContain('fields=name');
         expect(reqArg.url).not.toContain('offset');

--- a/__tests__/core-utils/reveal.test.js
+++ b/__tests__/core-utils/reveal.test.js
@@ -676,6 +676,173 @@ describe('fetchRecordGET fn test', () => {
       });
   });
 
+  it('should call rootReject when Promise.all rejects', (done) => {
+    const promiseAllError = new Error('Promise.all internal failure');
+    const promiseAllSpy = jest
+      .spyOn(Promise, 'all')
+      .mockRejectedValueOnce(promiseAllError);
+
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: () => Promise.resolve(getSuccessResponse),
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest
+      .spyOn(testSkyflowClient, 'getAccessToken')
+      .mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], optionsFalse)
+      .then(
+        () => {
+          promiseAllSpy.mockRestore();
+          done(new Error('should have rejected'));
+        },
+        (err) => {
+          promiseAllSpy.mockRestore();
+          expect(err).toBe(promiseAllError);
+          done();
+        }
+      )
+      .catch((err) => {
+        promiseAllSpy.mockRestore();
+        done(err);
+      });
+  });
+
+  it('should not include ids key in error response for column-based record', (done) => {
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: () => Promise.reject(getErrorResponse),
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest
+      .spyOn(testSkyflowClient, 'getAccessToken')
+      .mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordColumn], optionsFalse)
+      .then(
+        (res) => {},
+        (err) => {
+          expect(err.errors[0].ids).toBeUndefined();
+          expect(err.errors[0].columnName).toBe(getRecordColumn.columnName);
+          done();
+        }
+      )
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should include record with empty fields when fields key is missing in vault response', (done) => {
+    const responseWithMissingFields = {
+      records: [{ skyflow_id: 'id1' }], // no `fields` key
+    };
+
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: () => Promise.resolve(responseWithMissingFields),
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest
+      .spyOn(testSkyflowClient, 'getAccessToken')
+      .mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], optionsFalse)
+      .then((res) => {
+        expect(res.records.length).toBe(1);
+        expect(res.records[0].fields).toEqual({ id: '' });
+        expect(res.records[0].table).toBe(getRecordID.table);
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should set id to empty string in success record when skyflow_id is absent', (done) => {
+    const responseWithoutSkyflowId = {
+      records: [
+        {
+          fields: {
+            card_number: '4111111111111111',
+            // no skyflow_id
+          },
+          table: 'pii_fields',
+        },
+      ],
+    };
+
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: () => Promise.resolve(responseWithoutSkyflowId),
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest
+      .spyOn(testSkyflowClient, 'getAccessToken')
+      .mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordID], optionsFalse)
+      .then((res) => {
+        expect(res.records.length).toBe(1);
+        expect(res.records[0].fields.id).toBe('');
+        expect(res.records[0].fields.card_number).toBe('4111111111111111');
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('should include columnName in error response when column-based record fails', (done) => {
+    jest.spyOn(ClientModule, 'default').mockImplementation(() => ({
+      request: () => Promise.reject(getErrorResponse),
+    }));
+
+    const testSkyflowClient = new Skyflow({
+      vaultID: '1234',
+      vaultURL: 'https://url.com',
+      getBearerToken: () => Promise.resolve('valid_token'),
+    });
+
+    jest
+      .spyOn(testSkyflowClient, 'getAccessToken')
+      .mockResolvedValue('valid token');
+
+    fetchRecordsGET(testSkyflowClient, [getRecordColumn], optionsFalse)
+      .then(
+        (res) => {},
+        (err) => {
+          expect(err.errors.length).toBe(1);
+          expect(err.errors[0].error.code).toBe(404);
+          expect(err.errors[0].columnName).toBe(getRecordColumn.columnName);
+          done();
+        }
+      )
+      .catch((err) => {
+        done(err);
+      });
+  });
+
   it('should include fields params in url when fields are specified in options', (done) => {
     let reqArg;
     jest.spyOn(ClientModule, 'default').mockImplementation(() => ({

--- a/example/src/RevealElements.tsx
+++ b/example/src/RevealElements.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import {
+  OrderBy,
   RedactionType,
   RevealElement,
   useRevealContainer,
@@ -27,47 +28,90 @@ const RevealElements = (props) => {
   };
 
   const handleGet = () =>{
-    const getRecord1 = {
-      ids: [
-        '<SKYFLOW_ID_1>',
-        '<SKYFLOW_ID_2>',
-      ],
+    const getRecordByIds = {
+      ids: ['<SKYFLOW_ID_1>', '<SKYFLOW_ID_2>'],
       table: 'cards',
     };
 
-    const getRecord2 = {
+    const getRecordByColumn = {
       table: 'cards',
       columnName: '<COLUMN_NAME>',
       columnValues: ['<COLUMN_VALUE_1>', '<COLUMN_VALUE_2>'],
     };
 
-    const getRequest1 = { records: [getRecord1] };
-
-    const getRequest2 = {
-      records: [
-        { ...getRecord1, redaction: RedactionType.PLAIN_TEXT },
-        { ...getRecord2, redaction: RedactionType.PLAIN_TEXT },
-      ],
-    };
-
-    // Get Tokens by Skyflow ID
+    // Get tokens by Skyflow ID
     skyflowContainer
-      .get(getRequest1, { tokens: true })
+      .get(
+        { records: [getRecordByIds] },
+        { tokens: true }
+      )
       .then((response) => {
-        console.log('Get request 1 Success', JSON.stringify(response));
+        console.log('Get tokens Success', JSON.stringify(response));
       })
       .catch((err) => {
-        console.error('Get request 1 Failed', JSON.stringify(err));
+        console.error('Get tokens Failed', JSON.stringify(err));
       });
 
-    // get by Skyflow ID and Column Values
+    // Get plain text by Skyflow ID and column values
     skyflowContainer
-      .get(getRequest2, { tokens: false })
+      .get(
+        {
+          records: [
+            { ...getRecordByIds, redaction: RedactionType.PLAIN_TEXT },
+            { ...getRecordByColumn, redaction: RedactionType.PLAIN_TEXT },
+          ],
+        },
+        { tokens: false }
+      )
       .then((response) => {
-        console.log('Get request 2 Success', JSON.stringify(response));
+        console.log('Get plain text Success', JSON.stringify(response));
       })
       .catch((err) => {
-        console.error('Get request 2 Failed', JSON.stringify(err));
+        console.error('Get plain text Failed', JSON.stringify(err));
+      });
+
+    // Get specific fields only (column-scoped policy compatible)
+    skyflowContainer
+      .get(
+        {
+          records: [
+            { ...getRecordByIds, redaction: RedactionType.PLAIN_TEXT },
+          ],
+        },
+        {
+          tokens: false,
+          fields: ['occupation', 'annual_income'],
+        }
+      )
+      .then((response) => {
+        console.log('Get with fields Success', JSON.stringify(response));
+      })
+      .catch((err) => {
+        console.error('Get with fields Failed', JSON.stringify(err));
+      });
+
+    // Get with pagination and ordering
+    skyflowContainer
+      .get(
+        {
+          records: [
+            { ...getRecordByColumn, redaction: RedactionType.PLAIN_TEXT },
+          ],
+        },
+        {
+          tokens: false,
+          fields: ['name', 'email'],
+          offset: '0',
+          limit: '10',
+          orderBy: OrderBy.ASCENDING,
+          downloadURL: false,
+        }
+      )
+      .then((response) => {
+        console.log('Get with pagination Success', JSON.stringify(response));
+      })
+      .catch((err) => {
+        console.error('Get with pagination Failed', JSON.stringify(err));
       });
   };
 

--- a/example/src/RevealElements.tsx
+++ b/example/src/RevealElements.tsx
@@ -75,13 +75,14 @@ const RevealElements = (props) => {
       .get(
         {
           records: [
-            { ...getRecordByIds, redaction: RedactionType.PLAIN_TEXT },
+            {
+              ...getRecordByIds,
+              redaction: RedactionType.PLAIN_TEXT,
+              fields: ['occupation', 'annual_income'],
+            },
           ],
         },
-        {
-          tokens: false,
-          fields: ['occupation', 'annual_income'],
-        }
+        { tokens: false }
       )
       .then((response) => {
         console.log('Get with fields Success', JSON.stringify(response));
@@ -95,14 +96,17 @@ const RevealElements = (props) => {
       .get(
         {
           records: [
-            { ...getRecordByColumn, redaction: RedactionType.PLAIN_TEXT },
+            {
+              ...getRecordByColumn,
+              redaction: RedactionType.PLAIN_TEXT,
+              fields: ['name', 'email'],
+              offset: '0',
+              limit: '10',
+            },
           ],
         },
         {
           tokens: false,
-          fields: ['name', 'email'],
-          offset: '0',
-          limit: '10',
           orderBy: OrderBy.ASCENDING,
           downloadURL: false,
         }

--- a/src/core-utils/element-validations/index.ts
+++ b/src/core-utils/element-validations/index.ts
@@ -617,22 +617,30 @@ export const validateGetInput = (
       }
     }
 
-    if (
-      Object.prototype.hasOwnProperty.call(record, 'offset') &&
-      typeof record.offset !== 'string'
-    ) {
-      throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET, [
-        `${index}`,
-      ]);
+    if (Object.prototype.hasOwnProperty.call(record, 'offset')) {
+      if (typeof record.offset !== 'string') {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET, [
+          `${index}`,
+        ]);
+      }
+      if (record.offset === '') {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_OFFSET_IN_GET, [
+          `${index}`,
+        ]);
+      }
     }
 
-    if (
-      Object.prototype.hasOwnProperty.call(record, 'limit') &&
-      typeof record.limit !== 'string'
-    ) {
-      throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET, [
-        `${index}`,
-      ]);
+    if (Object.prototype.hasOwnProperty.call(record, 'limit')) {
+      if (typeof record.limit !== 'string') {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET, [
+          `${index}`,
+        ]);
+      }
+      if (record.limit === '') {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_LIMIT_IN_GET, [
+          `${index}`,
+        ]);
+      }
     }
 
     if (Object.prototype.hasOwnProperty.call(record, 'fields')) {

--- a/src/core-utils/element-validations/index.ts
+++ b/src/core-utils/element-validations/index.ts
@@ -14,6 +14,7 @@ import {
   IGetInput,
   IGetOptions,
   IInsertRecordInput,
+  OrderBy,
   RedactionType,
   RevealElementInput,
 } from '../../utils/constants';
@@ -442,6 +443,55 @@ export const validateGetInput = (
     typeof options?.tokens !== 'boolean'
   ) {
     throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_TOKENS_IN_GET);
+  }
+
+  if (
+    options &&
+    Object.prototype.hasOwnProperty.call(options, 'offset') &&
+    typeof options.offset !== 'string'
+  ) {
+    throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET);
+  }
+
+  if (
+    options &&
+    Object.prototype.hasOwnProperty.call(options, 'limit') &&
+    typeof options.limit !== 'string'
+  ) {
+    throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET);
+  }
+
+  if (
+    options &&
+    Object.prototype.hasOwnProperty.call(options, 'downloadURL') &&
+    typeof options.downloadURL !== 'boolean'
+  ) {
+    throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_DOWNLOAD_URL_IN_GET);
+  }
+
+  if (
+    options &&
+    Object.prototype.hasOwnProperty.call(options, 'orderBy') &&
+    !Object.values(OrderBy).includes(options.orderBy as OrderBy)
+  ) {
+    throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_ORDER_BY_IN_GET);
+  }
+
+  if (options && Object.prototype.hasOwnProperty.call(options, 'fields')) {
+    if (!Array.isArray(options.fields)) {
+      throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FIELDS_IN_GET);
+    }
+    if (options.fields.length === 0) {
+      throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_FIELDS_IN_GET);
+    }
+    (options.fields as any[]).forEach((field: any) => {
+      if (typeof field !== 'string') {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FIELD_VALUE_IN_GET);
+      }
+      if (!field) {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_FIELD_VALUE_IN_GET);
+      }
+    });
   }
 
   records.forEach((record: any, index: number) => {

--- a/src/core-utils/element-validations/index.ts
+++ b/src/core-utils/element-validations/index.ts
@@ -447,22 +447,6 @@ export const validateGetInput = (
 
   if (
     options &&
-    Object.prototype.hasOwnProperty.call(options, 'offset') &&
-    typeof options.offset !== 'string'
-  ) {
-    throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET);
-  }
-
-  if (
-    options &&
-    Object.prototype.hasOwnProperty.call(options, 'limit') &&
-    typeof options.limit !== 'string'
-  ) {
-    throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET);
-  }
-
-  if (
-    options &&
     Object.prototype.hasOwnProperty.call(options, 'downloadURL') &&
     typeof options.downloadURL !== 'boolean'
   ) {
@@ -477,23 +461,6 @@ export const validateGetInput = (
     throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_ORDER_BY_IN_GET);
   }
 
-  if (options && Object.prototype.hasOwnProperty.call(options, 'fields')) {
-    if (!Array.isArray(options.fields)) {
-      throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FIELDS_IN_GET);
-    }
-    if (options.fields.length === 0) {
-      throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_FIELDS_IN_GET);
-    }
-    (options.fields as any[]).forEach((field: any) => {
-      if (typeof field !== 'string') {
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FIELD_VALUE_IN_GET);
-      }
-      if (!field) {
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_FIELD_VALUE_IN_GET);
-      }
-    });
-  }
-
   records.forEach((record: any, index: number) => {
     if (Object.keys(record).length === 0) {
       throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_RECORDS_GET);
@@ -503,10 +470,9 @@ export const validateGetInput = (
         `${index}`,
       ]);
     }
-    if (record.ids && record.ids.length > 0) {
-      record.ids?.forEach((skyflowId) => {
+    record.ids?.forEach((skyflowId) => {
       if (!skyflowId) {
-          throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_SKYFLOWID_IN_GET, [
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_SKYFLOWID_IN_GET, [
           `${index}`,
         ]);
       }
@@ -517,7 +483,6 @@ export const validateGetInput = (
         );
       }
     });
-    }
     if (!Object.prototype.hasOwnProperty.call(record, 'table')) {
       throw new SkyflowError(SKYFLOW_ERROR_CODE.MISSING_TABLE_IN_GET, [
         `${index}`,
@@ -650,6 +615,49 @@ export const validateGetInput = (
           SKYFLOW_ERROR_CODE.REDACTION_WITH_TOKENS_NOT_SUPPORTED
         );
       }
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(record, 'offset') &&
+      typeof record.offset !== 'string'
+    ) {
+      throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_OFFSET_IN_GET, [
+        `${index}`,
+      ]);
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(record, 'limit') &&
+      typeof record.limit !== 'string'
+    ) {
+      throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_LIMIT_IN_GET, [
+        `${index}`,
+      ]);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(record, 'fields')) {
+      if (!Array.isArray(record.fields)) {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FIELDS_IN_GET, [
+          `${index}`,
+        ]);
+      }
+      if (record.fields.length === 0) {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_FIELDS_IN_GET, [
+          `${index}`,
+        ]);
+      }
+      record.fields.forEach((field: any) => {
+        if (typeof field !== 'string') {
+          throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FIELD_VALUE_IN_GET, [
+            `${index}`,
+          ]);
+        }
+        if (!field) {
+          throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_FIELD_VALUE_IN_GET, [
+            `${index}`,
+          ]);
+        }
+      });
     }
   });
 };

--- a/src/core-utils/element-validations/index.ts
+++ b/src/core-utils/element-validations/index.ts
@@ -498,17 +498,15 @@ export const validateGetInput = (
     if (Object.keys(record).length === 0) {
       throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_RECORDS_GET);
     }
-    if (record.ids?.length === 0) {
-      throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_IDS_IN_GET, [`${index}`]);
-    }
     if (record.ids != null && !(record.ids && Array.isArray(record.ids))) {
       throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_IDS_IN_GET, [
         `${index}`,
       ]);
     }
-    record.ids?.forEach((skyflowId) => {
+    if (record.ids && record.ids.length > 0) {
+      record.ids?.forEach((skyflowId) => {
       if (!skyflowId) {
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_SKYFLOWID_IN_GET, [
+          throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_SKYFLOWID_IN_GET, [
           `${index}`,
         ]);
       }
@@ -519,6 +517,7 @@ export const validateGetInput = (
         );
       }
     });
+    }
     if (!Object.prototype.hasOwnProperty.call(record, 'table')) {
       throw new SkyflowError(SKYFLOW_ERROR_CODE.MISSING_TABLE_IN_GET, [
         `${index}`,

--- a/src/core-utils/reveal/index.ts
+++ b/src/core-utils/reveal/index.ts
@@ -203,11 +203,12 @@ export const fetchRecordsGET = async (
                   (resolvedResult: any) => {
                     const recordsData: any[] = resolvedResult.records;
                     recordsData.forEach((fieldData) => {
-                      const id = fieldData.fields.skyflow_id;
-                      const currentRecord = {
+                      const fields = fieldData?.fields ?? {};
+                      const skyflowId = fields?.skyflow_id;
+                      const currentRecord: any = {
                         fields: {
-                          id,
-                          ...fieldData.fields,
+                          ...(skyflowId ? { id: skyflowId } : {id: ''}),
+                          ...fields,
                         },
                         table: skyflowIdRecord.table,
                       };
@@ -223,7 +224,9 @@ export const fetchRecordsGET = async (
                           code: rejectedResult?.error?.code,
                           description: rejectedResult?.error?.description,
                         },
-                        ids: skyflowIdRecord.ids,
+                        ...(skyflowIdRecord.ids
+                          ? { ids: skyflowIdRecord.ids }
+                          : {}),
                         ...(skyflowIdRecord?.columnName
                           ? { columnName: skyflowIdRecord?.columnName }
                           : {}),
@@ -265,7 +268,7 @@ export const fetchRecordsGET = async (
               rootReject({ records: recordsResponse, errors: errorResponse });
           })
           .catch((err) => {
-            console.log(err);
+            rootReject(err);
           });
       })
       .catch((err) => {

--- a/src/core-utils/reveal/index.ts
+++ b/src/core-utils/reveal/index.ts
@@ -299,16 +299,16 @@ export const getRecordsFromVault = (
     paramList += `redaction=${getRecord.redaction}&`;
   }
 
-  options?.fields?.forEach((field) => {
+  getRecord.fields?.forEach((field) => {
     paramList += `fields=${field}&`;
   });
 
-  if (options && Object.prototype.hasOwnProperty.call(options, 'offset')) {
-    paramList += `offset=${options.offset}&`;
+  if (getRecord.offset !== undefined) {
+    paramList += `offset=${getRecord.offset}&`;
   }
 
-  if (options && Object.prototype.hasOwnProperty.call(options, 'limit')) {
-    paramList += `limit=${options.limit}&`;
+  if (getRecord.limit !== undefined) {
+    paramList += `limit=${getRecord.limit}&`;
   }
 
   if (options && Object.prototype.hasOwnProperty.call(options, 'downloadURL')) {

--- a/src/core-utils/reveal/index.ts
+++ b/src/core-utils/reveal/index.ts
@@ -296,7 +296,31 @@ export const getRecordsFromVault = (
   }
 
   if (getRecord?.redaction) {
-    paramList += `redaction=${getRecord.redaction}`;
+    paramList += `redaction=${getRecord.redaction}&`;
+  }
+
+  options?.fields?.forEach((field) => {
+    paramList += `fields=${field}&`;
+  });
+
+  if (options && Object.prototype.hasOwnProperty.call(options, 'offset')) {
+    paramList += `offset=${options.offset}&`;
+  }
+
+  if (options && Object.prototype.hasOwnProperty.call(options, 'limit')) {
+    paramList += `limit=${options.limit}&`;
+  }
+
+  if (options && Object.prototype.hasOwnProperty.call(options, 'downloadURL')) {
+    paramList += `downloadURL=${options.downloadURL}&`;
+  }
+
+  if (options && Object.prototype.hasOwnProperty.call(options, 'orderBy')) {
+    paramList += `order_by=${options.orderBy}&`;
+  }
+
+  if (paramList.endsWith('&')) {
+    paramList = paramList.slice(0, -1);
   }
 
   const vault = config.vaultURL;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   ElementType,
   Env,
   LogLevel,
+  OrderBy,
   ValidationRuleType,
   RedactionType,
   SkyflowRevealElementRef,

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -261,6 +261,9 @@ export interface IGetRecord {
   table: string;
   columnName?: string;
   columnValues?: string[];
+  fields?: string[];
+  offset?: string;
+  limit?: string;
 }
 
 export interface IGetInput {
@@ -269,9 +272,6 @@ export interface IGetInput {
 
 export interface IGetOptions {
   tokens?: Boolean;
-  fields?: string[];
-  offset?: string;
-  limit?: string;
   downloadURL?: boolean;
   orderBy?: OrderBy;
 }

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -245,6 +245,12 @@ export enum ContainerType {
   COMPOSABLE = 'COMPOSABLE',
 }
 
+export enum OrderBy {
+  ASCENDING = 'ASCENDING',
+  DESCENDING = 'DESCENDING',
+  NONE = 'NONE',
+}
+
 export const PUREJS_TYPES = {
   GET: 'GET',
 };
@@ -263,6 +269,11 @@ export interface IGetInput {
 
 export interface IGetOptions {
   tokens?: Boolean;
+  fields?: string[];
+  offset?: string;
+  limit?: string;
+  downloadURL?: boolean;
+  orderBy?: OrderBy;
 }
 
 export const CARD_ICON_DEFAULT_STYLE = {

--- a/src/utils/logs/index.ts
+++ b/src/utils/logs/index.ts
@@ -216,17 +216,17 @@ const logs = {
     MISSING_IDS_OR_COLUMN_VALUES_IN_GET:
     `${SDK_NAME_VERSION} Validation error. Both 'ids' or 'columnValues' keys are missing. Either provide 'ids' or 'columnValues' with 'columnName' to fetch records.`,
     INVALID_FIELDS_IN_GET:
-      `${SDK_NAME_VERSION} Validation error. Invalid 'fields' in get options. Specify a value of type array instead.`,
+      `${SDK_NAME_VERSION} Validation error. Invalid 'fields' key in records at index %s1. Specify a value of type array instead.`,
     EMPTY_FIELDS_IN_GET:
-      `${SDK_NAME_VERSION} Validation error. 'fields' in get options cannot be empty. Specify a non-empty array instead.`,
+      `${SDK_NAME_VERSION} Validation error. 'fields' key cannot be empty in records at index %s1. Specify a non-empty array instead.`,
     EMPTY_FIELD_VALUE_IN_GET:
-      `${SDK_NAME_VERSION} Validation error. 'fields' in get options contains an empty string. Specify non-empty string values.`,
+      `${SDK_NAME_VERSION} Validation error. 'fields' array contains an empty string in records at index %s1. Specify non-empty string values.`,
     INVALID_FIELD_VALUE_IN_GET:
-      `${SDK_NAME_VERSION} Validation error. 'fields' in get options contains a non-string value. Specify string values instead.`,
+      `${SDK_NAME_VERSION} Validation error. 'fields' array contains a non-string value in records at index %s1. Specify string values instead.`,
     INVALID_OFFSET_IN_GET:
-      `${SDK_NAME_VERSION} Validation error. Invalid 'offset' in get options. Specify a value of type string instead.`,
+      `${SDK_NAME_VERSION} Validation error. Invalid 'offset' in records at index %s1. Specify a value of type string instead.`,
     INVALID_LIMIT_IN_GET:
-      `${SDK_NAME_VERSION} Validation error. Invalid 'limit' in get options. Specify a value of type string instead.`,
+      `${SDK_NAME_VERSION} Validation error. Invalid 'limit' in records at index %s1. Specify a value of type string instead.`,
     INVALID_DOWNLOAD_URL_IN_GET:
       `${SDK_NAME_VERSION} Validation error. Invalid 'downloadURL' in get options. Specify a boolean value instead.`,
     INVALID_ORDER_BY_IN_GET:

--- a/src/utils/logs/index.ts
+++ b/src/utils/logs/index.ts
@@ -215,6 +215,22 @@ const logs = {
     EMPTY_COLUMN_VALUE: `${SDK_NAME_VERSION} Validation error. Column Value is empty in records at index %s1`,
     MISSING_IDS_OR_COLUMN_VALUES_IN_GET:
     `${SDK_NAME_VERSION} Validation error. Both 'ids' or 'columnValues' keys are missing. Either provide 'ids' or 'columnValues' with 'columnName' to fetch records.`,
+    INVALID_FIELDS_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. Invalid 'fields' in get options. Specify a value of type array instead.`,
+    EMPTY_FIELDS_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. 'fields' in get options cannot be empty. Specify a non-empty array instead.`,
+    EMPTY_FIELD_VALUE_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. 'fields' in get options contains an empty string. Specify non-empty string values.`,
+    INVALID_FIELD_VALUE_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. 'fields' in get options contains a non-string value. Specify string values instead.`,
+    INVALID_OFFSET_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. Invalid 'offset' in get options. Specify a value of type string instead.`,
+    INVALID_LIMIT_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. Invalid 'limit' in get options. Specify a value of type string instead.`,
+    INVALID_DOWNLOAD_URL_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. Invalid 'downloadURL' in get options. Specify a boolean value instead.`,
+    INVALID_ORDER_BY_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. Invalid 'orderBy' in get options. Specify a valid OrderBy value (ASCENDING, DESCENDING, NONE).`,
     SKYFLOW_IDS_AND_COLUMN_NAME_BOTH_SPECIFIED:
     `${SDK_NAME_VERSION} Validation error. ids and columnName can not be specified together.`,
     GET_BY_SKYFLOWID_RESOLVED: '%s1 - GetById request is resolved.',

--- a/src/utils/logs/index.ts
+++ b/src/utils/logs/index.ts
@@ -225,8 +225,12 @@ const logs = {
       `${SDK_NAME_VERSION} Validation error. 'fields' array contains a non-string value in records at index %s1. Specify string values instead.`,
     INVALID_OFFSET_IN_GET:
       `${SDK_NAME_VERSION} Validation error. Invalid 'offset' in records at index %s1. Specify a value of type string instead.`,
+    EMPTY_OFFSET_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. 'offset' cannot be empty in records at index %s1. Specify a non-empty string value instead.`,
     INVALID_LIMIT_IN_GET:
       `${SDK_NAME_VERSION} Validation error. Invalid 'limit' in records at index %s1. Specify a value of type string instead.`,
+    EMPTY_LIMIT_IN_GET:
+      `${SDK_NAME_VERSION} Validation error. 'limit' cannot be empty in records at index %s1. Specify a non-empty string value instead.`,
     INVALID_DOWNLOAD_URL_IN_GET:
       `${SDK_NAME_VERSION} Validation error. Invalid 'downloadURL' in get options. Specify a boolean value instead.`,
     INVALID_ORDER_BY_IN_GET:

--- a/src/utils/skyflow-error-code/index.ts
+++ b/src/utils/skyflow-error-code/index.ts
@@ -330,6 +330,38 @@ const SKYFLOW_ERROR_CODE = {
     code: 400,
     description: logs.errorLogs.MISSING_IDS_OR_COLUMN_VALUES_IN_GET,
   },
+  INVALID_FIELDS_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.INVALID_FIELDS_IN_GET,
+  },
+  EMPTY_FIELDS_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.EMPTY_FIELDS_IN_GET,
+  },
+  EMPTY_FIELD_VALUE_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.EMPTY_FIELD_VALUE_IN_GET,
+  },
+  INVALID_FIELD_VALUE_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.INVALID_FIELD_VALUE_IN_GET,
+  },
+  INVALID_OFFSET_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.INVALID_OFFSET_IN_GET,
+  },
+  INVALID_LIMIT_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.INVALID_LIMIT_IN_GET,
+  },
+  INVALID_DOWNLOAD_URL_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.INVALID_DOWNLOAD_URL_IN_GET,
+  },
+  INVALID_ORDER_BY_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.INVALID_ORDER_BY_IN_GET,
+  },
   MISSING_RECORD_COLUMN_VALUE: {
     code: 400,
     description: logs.errorLogs.MISSING_RECORD_COLUMN_VALUE,

--- a/src/utils/skyflow-error-code/index.ts
+++ b/src/utils/skyflow-error-code/index.ts
@@ -350,9 +350,17 @@ const SKYFLOW_ERROR_CODE = {
     code: 400,
     description: logs.errorLogs.INVALID_OFFSET_IN_GET,
   },
+  EMPTY_OFFSET_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.EMPTY_OFFSET_IN_GET,
+  },
   INVALID_LIMIT_IN_GET: {
     code: 400,
     description: logs.errorLogs.INVALID_LIMIT_IN_GET,
+  },
+  EMPTY_LIMIT_IN_GET: {
+    code: 400,
+    description: logs.errorLogs.EMPTY_LIMIT_IN_GET,
   },
   INVALID_DOWNLOAD_URL_IN_GET: {
     code: 400,


### PR DESCRIPTION
### **SK-2658 — Add column/field selection support to get() API**
### **Problem**
The get() method did not support field-level filtering, making it incompatible with column-scoped vault policies. When a role only has access to a subset of columns, a get() call that fetches all columns returns a 403. Customers like PrizePicks need to pre-fill forms using only the permitted fields (e.g. occupation, annual_income) while excluding sensitive ones (e.g. ssn).

**Additionally**, the REST API supports several query parameters (fields, offset, limit, downloadURL, order_by) that had no SDK equivalent.

### Changes
**IGetOptions** — Extended with all missing REST API query parameters:

**fields**?: string[] — column filter; maps to ?fields=col1&fields=col2
**offset**?: string — pagination start
**limit**?: string — pagination page size
**downloadURL**?: boolean — request pre-signed download URLs
**orderBy**?: OrderBy — result ordering (ASCENDING | DESCENDING | NONE)
**OrderBy** enum — New enum added to constants and exported from the SDK entry point.